### PR TITLE
silence all warnings

### DIFF
--- a/src/lily_lexer.c
+++ b/src/lily_lexer.c
@@ -1430,6 +1430,7 @@ void lily_lexer(lily_lex_state *lexer)
             else {
                 ch++;
                 input_pos++;
+                token = tk_dot;
                 if (*ch == '.') {
                     ch++;
                     input_pos++;
@@ -1442,8 +1443,6 @@ void lily_lexer(lily_lex_state *lexer)
                         lily_raise(lexer->raiser, lily_SyntaxError,
                                 "'..' is not a valid token (expected 1 or 3 dots).\n");
                 }
-                else
-                    token = tk_dot;
             }
         }
         else if (group == CC_PLUS) {

--- a/src/lily_lexer.c
+++ b/src/lily_lexer.c
@@ -1290,7 +1290,7 @@ void lily_load_str(lily_lex_state *lexer, lily_lex_mode mode, const char *str)
 {
     lily_lex_entry *new_entry = get_entry(lexer);
 
-    new_entry->source = &str[0];
+    new_entry->source = (char*)&str[0];
     new_entry->entry_type = et_shallow_string;
 
     setup_entry(lexer, new_entry, mode);

--- a/src/lily_parser.c
+++ b/src/lily_parser.c
@@ -702,7 +702,7 @@ static lily_type *get_type(lily_parse_state *parser)
 {
     lily_lex_state *lex = parser->lex;
     lily_type *result;
-    lily_class *cls;
+    lily_class *cls = NULL;
 
     if (lex->token == tk_word)
         cls = resolve_class_name(parser);


### PR DESCRIPTION
the 2nd commit should be improved later, when __attribute__ ((noreturn)) is used for lily_raise().