### PR TITLE
Build on the BSD family

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,11 +1,19 @@
 file(GLOB lily_SOURCES *.c *.h)
 
+# BSD libc includes the dl* functions and there's no libdl on them.
+# Unfortunately, CMake doesn't seem to distinguish *BSD from the other *nixen.
+STRING(REGEX MATCH "BSD" IS_BSD ${CMAKE_SYSTEM_NAME})
+
 # The reason I've called this liblily but removed the prefix is so that I can
 # use liblily to build the lily executable.
 # -fPIC is vital: Apache's mod_lily will not build properly without it.
 add_library(liblily STATIC ${lily_SOURCES})
 if(NOT MSVC)
-    target_link_libraries(liblily dl)
+    if(IS_BSD)
+        target_link_libraries(liblily)
+    else()
+        target_link_libraries(liblily dl)
+    endif()
     set_target_properties(
         liblily
         PROPERTIES


### PR DESCRIPTION
BSD libc includes the dl* family of functions for loading dynamic libraries. I adjusted a CMake file to detect *BSD and not try to link against libdl on them.