### PR TITLE
Building with mingw on Windows

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -9,7 +9,7 @@ STRING(REGEX MATCH "BSD" IS_BSD ${CMAKE_SYSTEM_NAME})
 # -fPIC is vital: Apache's mod_lily will not build properly without it.
 add_library(liblily STATIC ${lily_SOURCES})
 if(NOT MSVC)
-    if(IS_BSD)
+    if(IS_BSD OR MINGW)
         target_link_libraries(liblily)
     else()
         target_link_libraries(liblily dl)

--- a/src/lily_msgbuf.c
+++ b/src/lily_msgbuf.c
@@ -250,7 +250,7 @@ static void msgbuf_add_errno_string(lily_msgbuf *msgbuf, int errno_val)
 {
     /* Assume that the message is of a reasonable sort of size. */
     char buffer[128];
-#ifdef _MSC_VER
+#ifdef _WIN32
     strerror_s(buffer, sizeof(buffer), errno_val);
 #else
     strerror_r(errno_val, buffer, sizeof(buffer));


### PR DESCRIPTION
Pretty straightforward - we don't need -ldl on Windows (like BSD).  However, we always have to use `strerror_s` on Windows