### PR TITLE
and/or emits Boolean not Integer

### DIFF
--- a/src/lily_emitter.c
+++ b/src/lily_emitter.c
@@ -2643,18 +2643,18 @@ static void eval_logical_op(lily_emit_state *emit, lily_ast *ast)
         int save_pos;
         lily_symtab *symtab = emit->symtab;
 
-        result = get_storage(emit, symtab->integer_class->type);
+        result = get_storage(emit, symtab->boolean_class->type);
 
         int truthy = (ast->op == expr_logical_and);
 
-        lily_u16_write_4(emit->code, o_get_integer, ast->line_num, truthy,
+        lily_u16_write_4(emit->code, o_get_boolean, ast->line_num, truthy,
                 result->reg_spot);
 
         lily_u16_write_2(emit->code, o_jump, 0);
         save_pos = lily_u16_pos(emit->code) - 1;
 
         lily_emit_leave_block(emit);
-        lily_u16_write_4(emit->code, o_get_integer, ast->line_num, !truthy,
+        lily_u16_write_4(emit->code, o_get_boolean, ast->line_num, !truthy,
                 result->reg_spot);
 
         lily_u16_insert(emit->code, save_pos, lily_u16_pos(emit->code)

--- a/test/pass/check_basics.lly
+++ b/test/pass/check_basics.lly
@@ -150,12 +150,12 @@ ok({||
 ok({||
     var v = ["a" => "a", "b" => "b"]
     var result = ((v["a"] == "a") && v["b"] == "b")
-    result != 0
+    result != false
     }(),                  "Check hash literal values.")
 ok({||
     var v = [1 => 1, 1 => 2, 2 => 2, 2 => 4]
     var result = ((v[1] == 2) && (v[2] == 4))
-    result != 0
+    result != false
     }(),                  "Hash literals take the right-most value.")
 
 # Tuple literals
@@ -204,16 +204,16 @@ ok({||
     var a = 1, b = 2, c = 3
     a = b = c
     var result = ((a == 3 && b == 3))
-    result == 1}(),                       "Basic assignment chain.")
+    result == true}(),                       "Basic assignment chain.")
 ok({||
     var a = 10, b = 20, c = 30
     a *= b *= c
     var result = (a == 6000 && b == 600 && c == 30)
-    result == 1}(),                       "Compound op assignment chain.")
+    result == true}(),                       "Compound op assignment chain.")
 ok({||
     var v = Triad(1, 2, 3)
     var result = (v.a == 3 && v.b == 3 && v.c == 3)
-    result == 1}(),                       "Assign chain using @prop.")
+    result == true}(),                       "Assign chain using @prop.")
 ok({||
     var v = Triad(1, 2, 3)
     v.a = 1
@@ -221,7 +221,7 @@ ok({||
     v.c = 3
     v.a = v.b = v.c
     var result = (v.a == 3 && v.b == 3 && v.c == 3)
-    result == 1}(),                       "Assign chain using .prop.")
+    result == true}(),                       "Assign chain using .prop.")
 
 # Vararg calls.
 


### PR DESCRIPTION
This should complete (hopefully) the great integer to boolean transition. I've patched the tests since they assumed that and/or expressions returned integers.
