### PR TITLE
Fix 2 uses of malloc() being used instead of lily_malloc()

### DIFF
--- a/src/lily_raiser.c
+++ b/src/lily_raiser.c
@@ -14,7 +14,7 @@ static const char *lily_error_names[] =
 lily_raiser *lily_new_raiser(void)
 {
     lily_raiser *raiser = lily_malloc(sizeof(lily_raiser));
-    lily_jump_link *first_jump = malloc(sizeof(lily_jump_link));
+    lily_jump_link *first_jump = lily_malloc(sizeof(lily_jump_link));
     first_jump->prev = NULL;
     first_jump->next = NULL;
 

--- a/src/lily_value_ops.c
+++ b/src/lily_value_ops.c
@@ -490,7 +490,7 @@ lily_function_val *lily_new_native_function_val(char *class_name,
    prelude to closure creation. */
 lily_function_val *lily_new_function_copy(lily_function_val *to_copy)
 {
-    lily_function_val *f = malloc(sizeof(lily_function_val));
+    lily_function_val *f = lily_malloc(sizeof(lily_function_val));
 
     *f = *to_copy;
     return f;


### PR DESCRIPTION
A couple of times Lily calls malloc() instead of its lily_malloc() wrapper, the latter of which checks for NULL.