### PR TITLE
Qualify an enum value with its class name when printing

### DIFF
--- a/src/lily_vm.c
+++ b/src/lily_vm.c
@@ -1819,6 +1819,8 @@ static void add_value_to_msgbuf(lily_vm_state *vm, lily_msgbuf *msgbuf,
     else if (v->flags & VAL_IS_ENUM) {
         lily_class *enum_cls = vm->class_table[v->value.instance->instance_id];
         int id = v->value.instance->variant_id;
+        lily_msgbuf_add(msgbuf, enum_cls->name);
+        lily_msgbuf_add(msgbuf, ".");
         lily_msgbuf_add(msgbuf, enum_cls->variant_members[id]->name);
         if (v->value.instance->num_values)
             add_list_like(vm, msgbuf, t, v, "(", ")");


### PR DESCRIPTION
Fixes #218.

This uses Class.Value whenever the enum is stringified, so:

    print(Speed.Fast)   # Speed.Fast
    print($"Going ^(Speed.Slow)")   # Going Speed.Slow

I'm not sure if that's necessarily desired, but I think it is and if a shorter stringification is needed the user should define an `as_string` or `to_s` method or whatever the convention is.