### PR TITLE
Hide <class>.new.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,6 @@ class Cat(name: String)
 # Types can almost always be inferred. This is List[Cat].
 var cats = [
     Cat("Muffin"),
-    Cat.new("Fuzzy"),
     "Snowball" |> Cat]
 
 # a |> b is the same as b(a)

--- a/src/lily_emitter.c
+++ b/src/lily_emitter.c
@@ -2113,6 +2113,11 @@ static void get_error_name(lily_emit_state *emit, lily_ast *ast,
     }
     else
         *name = "(anonymous)";
+
+    if (strcmp(*name, "<new>") == 0) {
+        *separator = "";
+        *name = "";
+    }
 }
 
 /* This is called when the call state (more on that later) has an argument that

--- a/src/lily_pkg_builtin.c
+++ b/src/lily_pkg_builtin.c
@@ -2969,7 +2969,7 @@ const char *dynaload_table[] =
     ,"!\000Function"
 
     ,"!\001Dynamic"
-    ,"m:new\0[A](A):Dynamic"
+    ,"m:<new>\0[A](A):Dynamic"
 
     ,"!\021List"
     ,"m:clear\0[A](List[A])"

--- a/test/fail/basic_syntax/integer_construct.lly
+++ b/test/fail/basic_syntax/integer_construct.lly
@@ -1,0 +1,6 @@
+#[
+SyntaxError: Class Integer does not have a constructor.
+    from integer_construct.lly:6
+]#
+
+var v = Integer(10)

--- a/test/fail/basic_syntax/integer_implicit_new.lly
+++ b/test/fail/basic_syntax/integer_implicit_new.lly
@@ -1,6 +1,0 @@
-#[
-SyntaxError: Cannot implicitly use Integer.new (it doesn't exist).
-    from integer_implicit_new.lly:6
-]#
-
-var v = Integer(10)

--- a/test/fail/exceptions/error_from_method.lly
+++ b/test/fail/exceptions/error_from_method.lly
@@ -2,7 +2,7 @@
 ValueError: Message.
 Traceback:
     from error_from_method.lly:13: in Example.action
-    from error_from_method.lly:16: in Example.new
+    from error_from_method.lly:16: in Example
     from error_from_method.lly:19: in __main__
 ]#
 

--- a/test/fail/exceptions/raise_in_constructor.lly
+++ b/test/fail/exceptions/raise_in_constructor.lly
@@ -1,7 +1,7 @@
 #[
 ValueError: Test
 Traceback:
-    from raise_in_constructor.lly:10: in Example.new
+    from raise_in_constructor.lly:10: in Example
     from raise_in_constructor.lly:13: in __main__
 ]#
 

--- a/test/fail/inheritance/inherit_misordered_generics.lly
+++ b/test/fail/inheritance/inherit_misordered_generics.lly
@@ -1,5 +1,5 @@
 #[
-SyntaxError: Argument #1 to First.new is invalid:
+SyntaxError: Argument #1 to First is invalid:
 Expected Type: A
 Received Type: B
     from inherit_misordered_generics.lly:10


### PR DESCRIPTION
I'm just wetting my feet, feel free to tear this apart.

I renamed `new` to `<new>` as this seemed to be the easiest way to make it inaccessible.

I modified the error printing functions to print just `Class` instead of `Class.new`. I had to add special cases which I don't like but the errors seem better (ex. putting code in `class Example`, doing `Example()` and seeing `Example` rather than `Example.new`).

I thought about other ways to do this, like making the function name NULL, but it seemed like a deeper change that didn't seem worth it.