### PR TITLE
Add more functions to the math module

### DIFF
--- a/manifest/pkg_math.lily
+++ b/manifest/pkg_math.lily
@@ -10,11 +10,23 @@ define abs(x: Integer): Integer
 ### Calculates the arc cosine of a double in radians.
 define acos(x: Double): Double
 
+### Calculates the hyperbolic arc cosine of a double in radians.
+define acosh(x: Double): Double
+
 ### Calculates the arc sine of a double in radians.
 define asin(x: Double): Double
 
+### Calculates the hyperbolic arc sine of a double in radians.
+define asinh(x: Double): Double
+
 ### Calculates the arc tangent of a double in radians.
 define atan(x: Double): Double
+
+### Calculates the hyperbolic arc tangent of a double in radians.
+define atanh(x: Double): Double
+
+### Calculate the cube root of a double.
+define cbrt(x: Double): Double
 
 ### Round a double up to the nearest integer.
 define ceil(x: Double): Double
@@ -27,6 +39,9 @@ define cosh(x: Double): Double
 
 ### Calculate e^x.
 define exp(x: Double): Double
+
+### Calculate 2^x.
+define exp2(x: Double): Double
 
 ### Calculates the absolute value of a double.
 define fabs(x: Double): Double
@@ -49,14 +64,23 @@ define ldexp(x: Double, y: Integer): Double
 ### Calculate the log of a double with base e.
 define log(x: Double): Double
 
+### Calculate the log of a double with base 2.
+define log2(x: Double): Double
+
 ### Calculate the log of a double with base 10.
 define log10(x: Double): Double
 
 ### Split a double into an integer and a fractional part <[ipart, fpart]>.
 define modf(x: Double): Tuple[Double, Double]
 
+### Calculate the square roots of x and y then the square root of them added together.
+define hypot(x: Double, y: Double): Double
+
 ### Calculate x^y.
 define pow(x: Double, y: Double): Double
+
+### Round a double to the nearest integer.
+define round(x: Double): Double
 
 ### Calculate the sine of a double in radians.
 define sin(x: Double): Double

--- a/src/lily_pkg_math.c
+++ b/src/lily_pkg_math.c
@@ -24,6 +24,13 @@ void lily_math__acos(lily_state *s)
     lily_return_double(s, acos(x));
 }
 
+void lily_math__acosh(lily_state *s)
+{
+    double x = lily_arg_double(s, 0);
+
+    lily_return_double(s, acosh(x));
+}
+
 void lily_math__asin(lily_state *s)
 {
     double x = lily_arg_double(s, 0);
@@ -31,11 +38,32 @@ void lily_math__asin(lily_state *s)
     lily_return_double(s, asin(x));
 }
 
+void lily_math__asinh(lily_state *s)
+{
+    double x = lily_arg_double(s, 0);
+
+    lily_return_double(s, asinh(x));
+}
+
 void lily_math__atan(lily_state *s)
 {
     double x = lily_arg_double(s, 0);
 
     lily_return_double(s, atan(x));
+}
+
+void lily_math__atanh(lily_state *s)
+{
+    double x = lily_arg_double(s, 0);
+
+    lily_return_double(s, atanh(x));
+}
+
+void lily_math__cbrt(lily_state *s)
+{
+    double x = lily_arg_double(s, 0);
+
+    lily_return_double(s, cbrt(x));
 }
 
 void lily_math__ceil(lily_state *s)
@@ -66,6 +94,13 @@ void lily_math__exp(lily_state *s)
     lily_return_double(s, exp(x));
 }
 
+void lily_math__exp2(lily_state *s)
+{
+    double x = lily_arg_double(s, 0);
+
+    lily_return_double(s, exp2(x));
+}
+
 void lily_math__fabs(lily_state *s)
 {
     double x = lily_arg_double(s, 0);
@@ -86,6 +121,14 @@ void lily_math__fmod(lily_state *s)
     double y = lily_arg_double(s, 1);
 
     lily_return_double(s, fmod(x, y));
+}
+
+void lily_math__hypot(lily_state *s)
+{
+    double x = lily_arg_double(s, 0);
+    double y = lily_arg_double(s, 1);
+
+    lily_return_double(s, hypot(x, y));
 }
 
 void lily_math__is_infinity(lily_state *s)
@@ -117,6 +160,13 @@ void lily_math__log(lily_state *s)
     lily_return_double(s, log(x));
 }
 
+void lily_math__log2(lily_state *s)
+{
+    double x = lily_arg_double(s, 0);
+
+    lily_return_double(s, log2(x));
+}
+
 void lily_math__log10(lily_state *s)
 {
     double x = lily_arg_double(s, 0);
@@ -146,6 +196,13 @@ void lily_math__pow(lily_state *s)
     double y = lily_arg_double(s, 1);
 
     lily_return_double(s, pow(x, y));
+}
+
+void lily_math__round(lily_state *s)
+{
+    double x = lily_arg_double(s, 0);
+
+    lily_return_double(s, round(x));
 }
 
 void lily_math__sin(lily_state *s)

--- a/src/lily_pkg_math_bindings.h
+++ b/src/lily_pkg_math_bindings.h
@@ -48,22 +48,30 @@ lily_call_entry_func lily_math_call_table[] = { \
     NULL, \
     lily_math__abs, \
     lily_math__acos, \
+    lily_math__acosh, \
     lily_math__asin, \
+    lily_math__asinh, \
     lily_math__atan, \
+    lily_math__atanh, \
+    lily_math__cbrt, \
     lily_math__ceil, \
     lily_math__cos, \
     lily_math__cosh, \
     lily_math__exp, \
+    lily_math__exp2, \
     lily_math__fabs, \
     lily_math__floor, \
     lily_math__fmod, \
+    lily_math__hypot, \
     lily_math__is_infinity, \
     lily_math__is_nan, \
     lily_math__ldexp, \
     lily_math__log, \
+    lily_math__log2, \
     lily_math__log10, \
     lily_math__modf, \
     lily_math__pow, \
+    lily_math__round, \
     lily_math__sin, \
     lily_math__sinh, \
     lily_math__sqrt, \

--- a/test/prelude/test_pkg_math.lily
+++ b/test/prelude/test_pkg_math.lily
@@ -24,6 +24,11 @@ class TestPkgMath < TestCase
         assert_near_equal(math.atan(math.pi / 4.0), 0.6657737500283538)
     }
 
+    public define test_cbrt
+    {
+        assert_near_equal(math.cbrt(27.0), 3.0)
+    }
+
     public define test_ceil
     {
         assert_near_equal(math.ceil(23.4), 24.0)
@@ -76,6 +81,11 @@ class TestPkgMath < TestCase
         assert_near_equal(math.log(math.exp(1.0)), 1.0)
     }
 
+    public define test_log2
+    {
+        assert_near_equal(math.log2(2.0), 1.0)
+    }
+
     public define test_log10
     {
         assert_near_equal(math.log10(10.0), 1.0)
@@ -96,6 +106,12 @@ class TestPkgMath < TestCase
         math.pow(999999.0, 99999.0)
             |> math.is_infinity
             |> assert_true
+    }
+
+    public define test_round
+    {
+        assert_near_equal(math.round(23.4), 23.0)
+        assert_near_equal(math.round(23.5), 24.0)
     }
 
     public define test_sin


### PR DESCRIPTION
Adds a few extra functions to the math module including:

- `acosh`, `asinh`, and `atanh` (missing hyperbolic functions)
- `cbrt`
- `exp2`
- `hypot`
- `log2`
- `round`


The beginning basis of Lily's math module seems to have been constructed around the limitations of C89 of which a few other scripting languages restrict themselves to, however Lily seems to not be restricted to C89 as there are already other functions in the math library which require C99 or newer such as "`is_nan`" https://en.cppreference.com/w/c/numeric/math.html

I was tempted to just add every applicable math function from C99 as Lily already has all the math functions from C89 however I was not sure if that would be desired or not so for this PR I have just added a few that I think make the most sense. although I am curious to know if just flat out including almost **all** of the C99 math functions would be acceptable in the context of Lily, if so then Ill submit a PR after to add more or something maybe.