### PR TITLE
Add a usability option to quickly display version information on the command line without having to open the REPL

### DIFF
--- a/run/lily.c
+++ b/run/lily.c
@@ -17,6 +17,7 @@ static void usage()
           "  -l            local imports only (don't use system dirs)\n"
           "  -gstart N     # of values to allow before a gc sweep\n"
           "  -gmul N       (# allowed * N) when sweep can't free anything\n"
+          "  -v            print version information\n"
           "  -h            show this help\n"
           , stderr);
     exit(EXIT_FAILURE);
@@ -35,6 +36,9 @@ static void process_args(int argc, char **argv, int *argc_offset)
         char *arg = argv[i];
         if (strcmp("-h", arg) == 0)
             usage();
+        else if (strcmp("-v", arg) == 0)
+            if (fputs("Lily " LILY_MAJOR "." LILY_MINOR "\n", stdout) == 0)
+                exit(EXIT_SUCCESS);
         else if (strcmp("-gstart", arg) == 0) {
             i++;
             if (i + 1 == argc)


### PR DESCRIPTION
In virtual environments like Docker, where fully automated deployment processes can be in full swing, this is often not even possible. Therefore, it's always nice to have such a usage option available, especially if the caller returns directly to the command line, so that deployments can continue or, depending on the information obtained (and especially how), can be gracefully terminated. Personally, I have so many development containers and build images that it would be ideal if they automatically included version tags, or something similar, in their final names. Therefore, I've made a small, but solid, and well-tested attempt to hopefully implement this in your project.